### PR TITLE
fix bug

### DIFF
--- a/C10-Elementary-Data-Structures/10.4.md
+++ b/C10-Elementary-Data-Structures/10.4.md
@@ -73,7 +73,8 @@ Draw the binary tree rooted at index 6 that is represented by the following fiel
 <td style="text-align: center">NIL</td>
 </tr>
 </tbody>
-</table>
+</table>
+
 
 ### `Answer`
 ![](./repo/s4/1.png)
@@ -103,7 +104,8 @@ Write an O(n)-time nonrecursive procedure that, given an n-node binary tree, pri
 
 ### Exercises 10.4-4
 ***
-Write an O(n)-time procedure that prints all the keys of an arbitrary rooted tree with n nodes, where the tree is stored using the left-child, right-sibling representation.
+Write an O(n)-time procedure that prints all the keys of an arbitrary rooted tree with n nodes, where the tree is stored using the left-child, right-sibling representation.
+
 
 ### `Answer`
 
@@ -133,10 +135,11 @@ Write an O(n)-time nonrecursive procedure that, given an n-node binary tree, pri
             	root = root->left  ? root->left :
                    	   root->right ? root->right : root->parent;
         	else if prev == root->left && root->right != NULL:
-            	root = root->right;
+            	prev = root;
+            	root = root -> right;
         	else:
-            	root = root->parent;
-            prev = root;
+            	prev = root;
+            	root = root -> parent;
             
 ### Exercises 10.4-6
 ***


### PR DESCRIPTION
We need to keep the `prev = root` before we move the `root` to next node, not saving `prev = root` after we move the root. You can check on paper.