### PR TITLE
Fix bug in 6.5-6

### DIFF
--- a/C06-Heapsort/6.5.md
+++ b/C06-Heapsort/6.5.md
@@ -55,7 +55,7 @@ Each exchange operation on line 5 of HEAP-INCREASE-KEY typically requires three 
 			error "New key is smaller than current key"
 		A[i] = key
 		while i > 1 and A[PARENT(i)] < key
-			A[i] = A[PARENT[i]]
+			A[i] = A[PARENT(i)]
 			i = PARENT(i)
 		A[i] = key
 

--- a/C06-Heapsort/6.5.md
+++ b/C06-Heapsort/6.5.md
@@ -54,9 +54,9 @@ Each exchange operation on line 5 of HEAP-INCREASE-KEY typically requires three 
 		if key < A[i]
 			error "New key is smaller than current key"
 		A[i] = key
-		while i > 0 and A[PARENT[i]] < A[i]
-			A[PARENT[i]] = A[i]
-			i = PARENT[i]
+		while i > 1 and A[PARENT(i)] < key
+			A[i] = A[PARENT[i]]
+			i = PARENT(i)
 		A[i] = key
 
 ### Exercises 6.5-7


### PR DESCRIPTION
- The original pseudocode cannot work because we need to compare the `key` and `A[PARENT(i)]` to reduce 3 assignments to just 1 assignment.
- About the brackets and index, I just follow the style of the original book (3rd edition), not a big issue.