### PR TITLE
update 6.5-8

### DIFF
--- a/C06-Heapsort/6.5.md
+++ b/C06-Heapsort/6.5.md
@@ -79,11 +79,35 @@ implementation of HEAP-DELETE that runs in O(lg n) time for an n-element max-hea
 
 ### `Answer`
 
-	HEAP-DELETE(A, i):
-  		A[i] = A[A.heap-size]
-  		A.heap-size -= 1
-  		MAX-HEAPIFY(A, i)
-  		
+```c
+HEAP-DELETE(A, i):
+	if A[i] < A[A.heap-size]
+		HEAP-INCREASE-KEY(A, i, A[A.heap-size])
+		A.heap-size -= 1
+	else
+		A[i] = A[A.heap-size]
+		A.heap-size -= 1
+		MAX-HEAPIFY(A,i)
+```
+**Notice: What's wrong with the implementation bellow?**
+	
+```c
+HEAP-DELETE(A, i):
+	A[i] = A[A.heap-size]
+	A.heap-size -= 1
+	MAX-HEAPIFY(A, i)
+```
+You can't assume there always be A[i] > A[A.heap-size].
+For example:
+```
+      10
+    /    \
+   5      9
+  / \    / \
+ 2   3  7   8
+```
+If you want to delete key 2, the A[A.heap-size] is 8. But 8 should climb up to the position of 5.
+
 ### Exercises 6.5-9
 ***
 Give an O(n lg k)-time algorithm to merge k sorted lists into one sorted list, where n is the


### PR DESCRIPTION
fix HEAP-DELETE(A, i)
forgot to think about the scenario that A[A.heap-size] > A[i]