### PR TITLE
Fixed issue in problem 2.1.4

### DIFF
--- a/C02-Getting-Started/2.1.md
+++ b/C02-Getting-Started/2.1.md
@@ -40,7 +40,7 @@ carry <- 0,
 for i <- A.length to 1
     C[i+1] <- (A[i] + B[i] + carry) % 2;
     carry = (A[i] + B[i] + carry)/2;
-C[i+1] <- carry;
+C[1] <- carry;
 return C
 ```
 


### PR DESCRIPTION
At the end of the for loop, C will have an empty first element. That element should take the value C[1] <- carry.