### PR TITLE
debugged String automaton code

### DIFF
--- a/C32-String-Matching/FA.c
+++ b/C32-String-Matching/FA.c
@@ -70,7 +70,7 @@ int main()
 	char *text = "abababacaba";
 	char *pattern = "ababaca";
 	int length = strlen(pattern);
-	int *array = (int*)malloc(3*(length+1));
+	int *array = (int*)malloc(sizeof(int)*3*(length+1));
 	
 	compute_transition_function(pattern,array,3);
 	


### PR DESCRIPTION
Allocated memory of sizeof(int) which was originally sizeof char leading to runtime errors.