### PR TITLE
fix a list infinite loop bug

### DIFF
--- a/C10-Elementary-Data-Structures/exercise_code/af-obj.c
+++ b/C10-Elementary-Data-Structures/exercise_code/af-obj.c
@@ -31,6 +31,8 @@ list_t allocate_object() {
     
     list_t new = free_list;
     free_list = NEXT(free_list);
+    NEXT(new_obj) = empty_list;
+    PREV(new_obj) = empty_list;
     return new;
 }
 


### PR DESCRIPTION
imagine such code:
list_t ls1 = alloc_object(1);
cons(2, ls1);
these code will make an infinite loop, because when alloc an object,
didn't modify its next, so it naturally links with object allocated later.
In this case, 2 will be next of 1, but when cons 2 and 1, 2 becomes prev of 1.
to avoid this bug, fix  alloc_object() function's bug by adding some statements.