### PR TITLE
Fixed error in 22.3-6

### DIFF
--- a/C22-Elementary-Graph-Algorithms/22.3.md
+++ b/C22-Elementary-Graph-Algorithms/22.3.md
@@ -102,7 +102,7 @@ Rewrite the procedure DFS, using a stack to eliminate recursion.
 			if COLOR[u] = WHITE:
 				COLOR[u] <- GRAY
 				d[u] <- time <- time+1
-			for each v in Adj[u]
+			for each v in Adj[u] from tail downto head
 				do if color[v] = WHITE
 					then π[v] <- u
 						 STACK.push(v)


### PR DESCRIPTION
New nodes from the adjacency lists have to be added to the stack in reversed order. If this detail is ignored the algorithm won't produce the same results as the recursive one.