### PR TITLE
链表不能判断区间

### DIFF
--- a/C11-Hash-Tables/11.2.md
+++ b/C11-Hash-Tables/11.2.md
@@ -20,7 +20,7 @@ Professor Marley hypothesizes that substantial performance gains can be obtained
 
 ### `Answer`
 * successful searches:没有影响
-* unsuccessful searches:当数据量大可以加速，可以提前判断元素是否在区间内
+* unsuccessful searches:当数据量大可以加速，可以提前判断元素超出范围(如递增排序,若小于首节点,则可判断为不成功查找)
 * insertions:降低了插入的速度，需要遍历链表插入在合适的位置
 * deletions:没有影响
 


### PR DESCRIPTION
链表尾节点需要遍历链表才能得知,所以即使是排序链表,也不能得到链表的值的区间,只能得到左节点的值