### PR TITLE
Change in pseudocode

### DIFF
--- a/C25-All-Pairs-Shortest-Paths/25.2.md
+++ b/C25-All-Pairs-Shortest-Paths/25.2.md
@@ -85,7 +85,6 @@ i, j, k = 1, 2,..., n, where ￼￼Φij(k) is the highest-numbered intermediate 
 			then print "no path from 'i' to 'j' exists"
 		else
 			PRINT-ALL-PAIRS-SHORTEST-PATH(Φ,i,Φ(i, j))
-			print Φ(i, j)
 			PRINT-ALL-PAIRS-SHORTEST-PATH(Φ,Φ(i, j),j)
 
 ### Exercises 25.2-8


### PR DESCRIPTION
We don't need to print Φ(i,j) as that is taken care of by PRINT-ALL-PAIRS-SHORTEST-PATH(Φ , Φ(i,j) , j). I am assuming initially for all edges (i,j) ∈ E,  Φ(i,j)=1. If this is so, then the edited code should be correct:)