### PR TITLE
Propose a new formula for 17.1-3

### DIFF
--- a/C17-Amortized-Analysis/17.1.md
+++ b/C17-Amortized-Analysis/17.1.md
@@ -19,4 +19,4 @@ In the worst case, going from 1[k-1 0's] (ie. 1000 -> 0111) takes k flips. Could
 A sequence of n operations is performed on a data structure. The ith operation costs i if i is an exact power of 2, and 1 otherwise. Use aggregate analysis to determine the amortized cost per operation.
 
 ### `Answer`
-Look at a sequence of n operations. Let k = floor(lb(n)). All operations cost equal to 1 * (1 - 2^k) / (1 - 2) + n - k = O(n), than each operation cost equal to O(n) / n = O(1).
+Look at a sequence of n operations. Let k = floor(lg(n)). All operations cost equal to 1 * (1 - 2^k) / (1 - 2) + n - k = O(n), than each operation cost equal to O(n) / n = O(1).

--- a/C17-Amortized-Analysis/17.1.md
+++ b/C17-Amortized-Analysis/17.1.md
@@ -19,4 +19,4 @@ In the worst case, going from 1[k-1 0's] (ie. 1000 -> 0111) takes k flips. Could
 A sequence of n operations is performed on a data structure. The ith operation costs i if i is an exact power of 2, and 1 otherwise. Use aggregate analysis to determine the amortized cost per operation.
 
 ### `Answer`
-Look at a sequence of n operations. Let k = floor(lg(n)). All operations cost equal to 1 * (1 - 2^k) / (1 - 2) + n - k = O(n), than each operation cost equal to O(n) / n = O(1).
+Look at a sequence of n operations. Let k = floor(lg(n)). All operations cost equal to 1 + 2 * (1 - 2^k) / (1 - 2) + n - k - 1 = 2 * 2^k + n - k - 2 = O(n), than each operation cost equal to O(n) / n = O(1).


### PR DESCRIPTION
Fix a sum of a geometric progression in 17.1-3

I would like to propose a formula that returns a more precision solution
in k-terms but the amortized cost doesn't depend on them at all even
though mathematical the proposed solution has a little bit better precision,
we can check for 9:

old formula: 1 * (1 - 2^k) / (1 - 2) + n - k = 1 * (1 - 2^3) / (1 - 2) +
9 - 3 = 7 + 9 - 3 = 13.
proposed formula: 2 * 2^k + n - k - 2 = 2 * 2^3 + 9 - 3 - 2 = 20.
The right answer is 1 + 2 + 1 + 4 + 1 + 1 + 1 + 8 + 1 = 20

But as it has been noticed, the sum has no impact on the answer.

Signed-off-by: Pavel Samolysov <samolisov@gmail.com>