### PR TITLE
Update 18.2.md : Arrow missing from image

### DIFF
--- a/C18-B-Trees/18.2.md
+++ b/C18-B-Trees/18.2.md
@@ -9,6 +9,8 @@ in order into an empty B-tree with minimum degree 2. Only draw the configuration
 ### `Answer`
 ![](./repo/s2/1.png)
 
+[Correction: There will be an arrow from between K and Q to M, i.e, if R is the root of the B.Tree, then R.C2 -> M]
+
 ### Exercises 18.2-2
 ***
 Explain under what circumstances, if any, redundant DISK-READ or DISK-WRITE operations are performed during the course of executing a call to B-TREE-INSERT. (A redundant DISK-READ is a DISK-READ for a page that is already in memory. A redundant DISK-WRITE writes to disk a page of information that is identical to what is already stored there.)


### PR DESCRIPTION
There will be an arrow from between K and Q (in the root node) to M, i.e, if R is the rot node of the B.Tree, then R.C2 -> M