### PR TITLE
Typo and correction on n range in exercise 1.2 - 2

### DIFF
--- a/C01-The-Role-of-Algorithms-in-Computing/1.2.md
+++ b/C01-The-Role-of-Algorithms-in-Computing/1.2.md
@@ -20,7 +20,7 @@ Suppose we are comparing implementations of insertion sort and merge sort on the
 ### `Answer`
 解方程 ![](http://latex.codecogs.com/gif.latex?8n^2=64nlg{n})
 
-for 2 < n < 43
+for 2 <= n <= 43
 
 
 ### Exercises 1.2-3

--- a/C01-The-Role-of-Algorithms-in-Computing/problem.md
+++ b/C01-The-Role-of-Algorithms-in-Computing/problem.md
@@ -3,7 +3,7 @@
 For each function **f**(n) and time t in the following table, determine the largest size n of a problem that can be solved in time t, assuming that the algorithm to solve the problem takes **f**(n) microseconds.
 
 ### `Answer`
-Item | 1 second | 1 miniute | 1 hour | 1 day | 1 month | 1 year | 1 century
+Item | 1 second | 1 minute | 1 hour | 1 day | 1 month | 1 year | 1 century
 :----:|----:|----:|----:|----:|----:|----:|----:
 ![](http://latex.codecogs.com/gif.latex?\\lg{n}) | ![](http://latex.codecogs.com/gif.latex?\\2^{10^6}})  | ![](http://latex.codecogs.com/gif.latex?\\2^{6*10^7}}) | ![](http://latex.codecogs.com/gif.latex?\\2^{36*10^8}}) | ![](http://latex.codecogs.com/gif.latex?\\2^{864*10^8}}) | ![](http://latex.codecogs.com/gif.latex?\\2^{25920*10^8}}) | ![](http://latex.codecogs.com/gif.latex?\\2^{315360*10^8}}) | ![](http://latex.codecogs.com/gif.latex?\\2^{31556736*10^8}})
 ![](http://latex.codecogs.com/gif.latex?\\/{n}^{1/2}) | ![](http://latex.codecogs.com/gif.latex?\\10^{12}) | ![](http://latex.codecogs.com/gif.latex?\\36*10^{14}) | ![](http://latex.codecogs.com/gif.latex?\\1296*10^{16}) | ![](http://latex.codecogs.com/gif.latex?\\746496*10^{16}) | ![](http://latex.codecogs.com/gif.latex?\\6718464*10^{18}) | ![](http://latex.codecogs.com/gif.latex?\\994519296*10^{18}) | ![](http://latex.codecogs.com/gif.latex?\\995827586973696*10^{16}) 


### PR DESCRIPTION
### Typo in file `C01-The-Role-of-Algorithms-in-Computing/problem.md`

### Correction exercise 1.2 - 2
The comparison operators are saying that numbers **2** and **43** are exclusive from the range when in fact they are inclusive. Proof:
MATLAB calculations
Functions used:
![image](https://github.com/gzc/CLRS/assets/72330887/6ef87a76-f50f-48e2-bcc9-9c8cfb2ff659)
![image](https://github.com/gzc/CLRS/assets/72330887/be818dbf-d528-4996-8260-86f9aca3c9b3)
____
## Lower bound
![image](https://github.com/gzc/CLRS/assets/72330887/e36edfa2-7988-4494-b142-b9a489dbd2df)
____
## Upper bound
![image](https://github.com/gzc/CLRS/assets/72330887/7875498f-e6c8-427f-b879-cc7930683961)
